### PR TITLE
fix: typo in value of UpToFifteen

### DIFF
--- a/dto_model/src/main/scala/de/dnpm/dip/rd/model/Hospitalization.scala
+++ b/dto_model/src/main/scala/de/dnpm/dip/rd/model/Hospitalization.scala
@@ -51,7 +51,7 @@ object Hospitalization
   {
     val Zero          = Value("none")
     val UpToFive      = Value("up-to-five")
-    val UpToFifteen   = Value("up-to-tifteen")
+    val UpToFifteen   = Value("up-to-fifteen")
     val UpToFifty     = Value("up-to-fifty")
     val OverFifty     = Value("over-fifty")
     val Unknown       = Value("unknown")


### PR DESCRIPTION
This fixes a typo in value that closes #1 